### PR TITLE
Change siren into siret

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -125,7 +125,7 @@ class Enrollment < ApplicationRecord
       'validation_de_convention' => validation_de_convention,
       'scopes' => scopes,
       'contacts' => contacts,
-      'siren' => siren,
+      'siret' => siret,
       'demarche' => demarche,
       'donnees' => donnees&.merge('destinataires' => donnees&.fetch('destinataires', {})),
       'state' => state,
@@ -163,7 +163,7 @@ class Enrollment < ApplicationRecord
       errors[:contacts] << "Vous devez renseigner le #{contact&.fetch('heading', nil)} avant de continuer" unless contact&.fetch('nom', false)&.present? && contact&.fetch('email', false)&.present?
     end
 
-    errors[:siren] << "Vous devez renseigner le SIREN de votre organisation avant de continuer" unless siren.present?
+    errors[:siret] << "Vous devez renseigner le SIRET de votre organisation avant de continuer" unless siret.present?
     errors[:demarche] << "Vous devez renseigner la description de la démarche avant de continuer" unless demarche && demarche['description'].present?
     errors[:demarche] << "Vous devez renseigner le fondement juridique de la démarche avant de continuer" unless demarche && demarche['fondement_juridique'].present?
     errors[:demarche] << "Vous devez renseigner le document associé au fondement juridique" unless (demarche && demarche['url_fondement_juridique'].present?) || documents.where(type: 'Document::LegalBasis').present?

--- a/app/policies/enrollment_policy.rb
+++ b/app/policies/enrollment_policy.rb
@@ -42,7 +42,7 @@ class EnrollmentPolicy < ApplicationPolicy
         :validation_de_convention,
         :fournisseur_de_donnees,
         :fournisseur_de_service,
-        :siren,
+        :siret,
         contacts: [:id, :heading, :nom, :email, :telephone_portable],
         demarche: [
           :intitule,

--- a/db/migrate/20180420135406_new_contractualization_form.rb
+++ b/db/migrate/20180420135406_new_contractualization_form.rb
@@ -5,7 +5,7 @@ class NewContractualizationForm < ActiveRecord::Migration[5.1]
     create_table :enrollments do |t|
       t.json :scopes
       t.column :contacts, 'json[]'
-      t.string :siren
+      t.string :siret
       t.json :demarche
       t.json :donnees
       t.string :state

--- a/db/migrate/20180829133613_change_siren_in_siret.rb
+++ b/db/migrate/20180829133613_change_siren_in_siret.rb
@@ -1,0 +1,5 @@
+class ChangeSirenInSiret < ActiveRecord::Migration[5.1]
+  def change
+  	rename_column :enrollments, :siren, :siret
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180816122600) do
+ActiveRecord::Schema.define(version: 20180829133613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20180816122600) do
   create_table "enrollments", force: :cascade do |t|
     t.json "scopes", default: {}
     t.json "contacts", array: true
-    t.string "siren"
+    t.string "siret"
     t.json "demarche"
     t.json "donnees", default: {"destinaires"=>{}}
     t.string "state"

--- a/spec/controllers/enrollments_controller_spec.rb
+++ b/spec/controllers/enrollments_controller_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe EnrollmentsController, type: :controller do
               },
               "contacts": [{"nom": "test"}],
               "scopes": {"dgfip_avis_imposition": "true"},
-              "siren": "12345",
+              "siret": "12345",
               "donnees": {"conservation": "12", "destinataires": {
                 "destinataire_dgfip_avis_imposition": "Destinaire Test"
                 }},

--- a/spec/factories/enrollment_api_particuliers.rb
+++ b/spec/factories/enrollment_api_particuliers.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     validation_de_convention true
 
     factory :sent_enrollment_api_particulier do
-      siren '12345'
+      siret '12345'
       state 'sent'
       donnees "conservation" => 12, "destinataires" => { "dgfip_avis_imposition" => "Destinaires des données"}
       scopes dgfip_avis_imposition: true

--- a/spec/factories/enrollment_dgfips.rb
+++ b/spec/factories/enrollment_dgfips.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     validation_de_convention true
 
     factory :sent_enrollment_dgfip do
-      siren '12345'
+      siret '12345'
       state 'sent'
       donnees "conservation" => 12, "destinataires" => { "dgfip_avis_imposition" => "Destinaires des données"}
       scopes dgfip_avis_imposition: true

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     validation_de_convention true
 
     factory :sent_enrollment do
-      siren '12345'
+      siret '12345'
       state 'sent'
       donnees "conservation" => 12, "destinataires" => { "dgfip_avis_imposition" => "Destinaires des données"}
       scopes dgfip_avis_imposition: true

--- a/test/fixtures/enrollments.yml
+++ b/test/fixtures/enrollments.yml
@@ -2,7 +2,7 @@
 enrollment_<%= i %>:
   scopes: '{"cnaf_quotient_familial":"1"}'
   contacts: '{"{\"id\":\"dpo\",\"heading\":\"Délégué à la protection des données\",\"nom\":\"Jean Martin\",\"email\":\"jean.martin@yopmail.com\"}","{\"id\":\"responsable_traitement\",\"heading\":\"Responsable de traitement\",\"nom\":\"Jean Martin\",\"email\":\"jean.martin@yopmail.com\"}","{\"id\":\"technique\",\"heading\":\"Responsable technique\",\"nom\":\"Jean Martin\",\"email\":\"jean.martin@yopmail.com\"}"}'
-  siren: 839517323
+  siret: 839517323
   demarche:
     intitule: "Enrollement <%= i %>"
     fondement_juridique: "cadre juridique"


### PR DESCRIPTION
This PR allow reviewers to access the applicant's Siret.
The Siret provides an `enseigne` that is more precise than the `raison_sociale`