### PR TITLE
Bug fix : allows old signup forms to be validated

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -138,7 +138,9 @@ class Enrollment < ApplicationRecord
     end
 
     # in a similar way, format dgfip_data_years
-    self.donnees['dgfip_data_years'] = donnees['dgfip_data_years'].transform_values { |e| e.to_s == "true" }
+    if donnees.key?('dgfip_data_years')
+      self.donnees['dgfip_data_years'] = donnees['dgfip_data_years'].transform_values { |e| e.to_s == "true" }
+    end
   end
 
   def set_company_info


### PR DESCRIPTION
Old signup forms, created before changes were made to the DGFIP form, and not yet validated could not be validated.

With this fix, they can be.
