### PR TITLE
Introduce webhooks for notifiers and bridges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
-      # redis:
-      #   image: redis
-      #   ports: ["6379:6379"]
-      #   options: --entrypoint redis-server
+      redis:
+        image: redis
+        ports: ["6379:6379"]
+        options: --entrypoint redis-server
 
     steps:
       - name: Dump Github context

--- a/Gemfile
+++ b/Gemfile
@@ -17,11 +17,13 @@ gem "omniauth-oauth2"
 gem "pg"
 gem "puma", "~> 3.12"
 gem "pundit"
+gem "redis"
 gem "rails", "~> 5.2.5"
 gem "rails-i18n"
 gem "sentry-ruby"
 gem "sentry-rails"
 gem "sib-api-v3-sdk"
+gem "sidekiq", "~> 5.0"
 gem "state_machines-activerecord"
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development do
   gem "standardrb"
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
+  gem "foreman"
 end
 
 gem "active_model_serializers", "~> 0.10.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    foreman (0.87.2)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -390,6 +391,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   factory_bot_rails
+  foreman
   guard-rspec
   guard-standardrb
   http

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       activesupport
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -231,6 +232,8 @@ GEM
       activesupport (>= 3.0.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.6)
@@ -265,6 +268,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.4.0)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -328,6 +332,11 @@ GEM
     sib-api-v3-sdk (5.4.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -404,10 +413,12 @@ DEPENDENCIES
   pundit
   rails (~> 5.2.5)
   rails-i18n
+  redis
   rspec-rails
   sentry-rails
   sentry-ruby
   sib-api-v3-sdk
+  sidekiq (~> 5.0)
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -v

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Backend de DataPass
+
 [![Rails tests](https://github.com/betagouv/signup-back/actions/workflows/ci.yml/badge.svg)](https://github.com/betagouv/signup-back/actions/workflows/ci.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/713ba5c1e90ee6a35937/maintainability)](https://codeclimate.com/github/betagouv/signup-back/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/713ba5c1e90ee6a35937/test_coverage)](https://codeclimate.com/github/betagouv/signup-back/test_coverage)
@@ -9,8 +10,8 @@ Pour le développement en local, suivez les instructions ci-dessous:
 
 ## Dépendances
 
-* ruby 2.7.3
-* postgresql 9.5
+- ruby 2.7.3
+- postgresql 9.5
 
 ## Installation
 
@@ -33,6 +34,12 @@ tests en continue:
 
 ```sh
 bundle exec guard
+```
+
+## Run
+
+```sh
+bundle exec foreman start -f Procfile.dev
 ```
 
 ## Brakeman

--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ suivante:
 ```sh
 bundle exec brakeman -Iconfig/brakeman.ignore
 ```
+
+## Documentation
+
+- [Implémentation des webhooks](./docs/webhooks.md)
+- [Personnalisation des emails associés aux
+  demandes](./app/views/enrollment_mailer/README.md)

--- a/app/bridges/abstract_webhook_bridge.rb
+++ b/app/bridges/abstract_webhook_bridge.rb
@@ -1,0 +1,18 @@
+class AbstractWebhookBridge < ApplicationBridge
+  def call
+    DeliverEnrollmentWebhookWorker.perform_async(
+      @enrollment.target_api,
+      webhook_payload,
+      @enrollment.id
+    )
+  end
+
+  private
+
+  def webhook_payload
+    WebhookSerializer.new(
+      @enrollment,
+      "validated"
+    ).serializable_hash
+  end
+end

--- a/app/bridges/francerelance_fc_bridge.rb
+++ b/app/bridges/francerelance_fc_bridge.rb
@@ -1,0 +1,2 @@
+class FrancerelanceFcBridge < FranceconnectBridge
+end

--- a/app/mailers/webhook_mailer.rb
+++ b/app/mailers/webhook_mailer.rb
@@ -1,0 +1,25 @@
+class WebhookMailer < ActionMailer::Base
+  layout false
+
+  def fail
+    @webhook_url = ENV["#{params[:target_api].upcase}_WEBHOOK_URL"]
+    @payload = JSON.pretty_generate(params[:payload])
+    @webhook_response_body = params[:webhook_response_body]
+    @webhook_response_status = params[:webhook_response_status]
+
+    mail(
+      subject: "[Datapass] Votre webhook endpoint est en défaut",
+      to: target_api_instructor_emails,
+      from: "datapass@api.gouv.fr",
+      cc: "datapass@api.gouv.fr"
+    )
+  end
+
+  private
+
+  def target_api_instructor_emails
+    User.where(
+      roles: ["#{params[:target_api]}:instructor"]
+    ).pluck(:email)
+  end
+end

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -74,37 +74,13 @@ class Enrollment < ActiveRecord::Base
       )
     end
 
-    before_transition sent: :validated do |enrollment, _|
-      if enrollment.target_api == "api_particulier" && !ENV["DISABLE_API_PARTICULIER_BRIDGE"].present?
-        ApiParticulierBridge.call(enrollment)
-      end
+    before_transition sent: :validated do |enrollment|
+      bridge_enable = !ENV["DISABLE_#{enrollment.target_api.upcase}_BRIDGE"].present?
 
-      if enrollment.target_api == "franceconnect" && !ENV["DISABLE_FRANCECONNECT_BRIDGE"].present?
-        FranceconnectBridge.call(enrollment)
-      end
-
-      if enrollment.target_api == "api_entreprise" && !ENV["DISABLE_API_ENTREPRISE_BRIDGE"].present?
-        ApiEntrepriseBridge.call(enrollment)
-      end
-
-      if enrollment.target_api == "api_droits_cnam" && !ENV["DISABLE_API_DROITS_CNAM_BRIDGE"].present?
-        ApiDroitsCnamBridge.call(enrollment)
-      end
-
-      if enrollment.target_api == "api_impot_particulier_fc_sandbox" && !ENV["DISABLE_API_IMPOT_PARTICULIER_BRIDGE"].present?
-        ApiImpotParticulierFcSandboxBridge.call(enrollment)
-      end
-
-      if enrollment.target_api == "francerelance_fc" && !ENV["DISABLE_FRANCECONNECT_BRIDGE"].present?
-        FranceconnectBridge.call(enrollment)
-      end
-
-      if enrollment.target_api == "aidants_connect" && !ENV["DISABLE_AIDANTS_CONNECT_BRIDGE"].present?
-        AidantsConnectBridge.call(enrollment)
-      end
-
-      if enrollment.target_api == "hubee" && !ENV["DISABLE_HUBEE_BRIDGE"].present?
-        HubeeBridge.call(enrollment)
+      if bridge_enable && enrollment.bridge
+        enrollment.bridge.call(
+          enrollment
+        )
       end
     end
 
@@ -121,6 +97,12 @@ class Enrollment < ActiveRecord::Base
     Kernel.const_get("#{self.class}Notifier")
   rescue NameError
     BaseNotifier
+  end
+
+  def bridge
+    Kernel.const_get("#{target_api.classify}Bridge")
+  rescue NameError
+    nil
   end
 
   def subscribers

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -94,7 +94,7 @@ class Enrollment < ActiveRecord::Base
   end
 
   def notifier_class
-    Kernel.const_get("#{self.class}Notifier")
+    Kernel.const_get("#{self.target_api.classify}Notifier")
   rescue NameError
     BaseNotifier
   end

--- a/app/notifiers/abstract_notifier.rb
+++ b/app/notifiers/abstract_notifier.rb
@@ -1,0 +1,45 @@
+class AbstractNotifier
+  attr_reader :enrollment
+
+  def initialize(enrollment)
+    @enrollment = enrollment
+  end
+
+  # :nocov:
+  def created
+    fail NotImplementedError
+  end
+
+  def updated(diff:, user_id:)
+    fail NotImplementedError
+  end
+
+  def owner_updated(diff:, user_id:)
+    fail NotImplementedError
+  end
+
+  def rgpd_contact_updated(diff:, user_id:, responsable_traitement_email:, dpo_email:)
+    fail NotImplementedError
+  end
+
+  def send_application(comment:, current_user:)
+    fail NotImplementedError
+  end
+
+  def notify(comment:, current_user:)
+    fail NotImplementedError
+  end
+
+  def review_application(comment:, current_user:)
+    fail NotImplementedError
+  end
+
+  def refuse_application(comment:, current_user:)
+    fail NotImplementedError
+  end
+
+  def validate_application(comment:, current_user:)
+    fail NotImplementedError
+  end
+  # :nocov:
+end

--- a/app/notifiers/api_entreprise_notifier.rb
+++ b/app/notifiers/api_entreprise_notifier.rb
@@ -1,0 +1,52 @@
+class ApiEntrepriseNotifier < AbstractNotifier
+  include WebhookNotifierMethods
+  include EmailNotifierMethods
+
+  def created
+    deliver_event_webhook(__method__)
+  end
+
+  def updated(diff:, user_id:)
+    deliver_event_webhook(__method__)
+  end
+
+  def owner_updated(diff:, user_id:)
+  end
+
+  def rgpd_contact_updated(diff:, user_id:, responsable_traitement_email:, dpo_email:)
+    notify_rgpd_contacts_by_email(
+      responsable_traitement_email: responsable_traitement_email,
+      dpo_email: dpo_email
+    )
+  end
+
+  def send_application(comment:, current_user:)
+    deliver_event_webhook(__method__)
+
+    notify_subscribers_by_email_for_sent_application(current_user: current_user)
+  end
+
+  def notify(comment:, current_user:)
+    deliver_event_webhook(__method__)
+  end
+
+  def review_application(comment:, current_user:)
+    deliver_event_webhook(__method__)
+  end
+
+  def refuse_application(comment:, current_user:)
+    deliver_event_webhook(__method__)
+  end
+
+  def validate_application(comment:, current_user:)
+    deliver_event_webhook(__method__)
+
+    if enrollment.responsable_traitement.present?
+      deliver_rgpd_email_for(:responsable_traitement)
+    end
+
+    if enrollment.dpo.present?
+      deliver_rgpd_email_for(:dpo)
+    end
+  end
+end

--- a/app/notifiers/api_entreprise_notifier.rb
+++ b/app/notifiers/api_entreprise_notifier.rb
@@ -4,6 +4,7 @@ class ApiEntrepriseNotifier < AbstractNotifier
 
   def created
     deliver_event_webhook(__method__)
+    deliver_created_mail_to_enrollment_creator if default_mailer_active?
   end
 
   def updated(diff:, user_id:)
@@ -22,24 +23,29 @@ class ApiEntrepriseNotifier < AbstractNotifier
 
   def send_application(comment:, current_user:)
     deliver_event_webhook(__method__)
+    deliver_event_mailer(__method__, comment) if default_mailer_active?
 
     notify_subscribers_by_email_for_sent_application(current_user: current_user)
   end
 
   def notify(comment:, current_user:)
     deliver_event_webhook(__method__)
+    deliver_event_mailer(__method__, comment) if default_mailer_active?
   end
 
   def review_application(comment:, current_user:)
     deliver_event_webhook(__method__)
+    deliver_event_mailer(__method__, comment) if default_mailer_active?
   end
 
   def refuse_application(comment:, current_user:)
     deliver_event_webhook(__method__)
+    deliver_event_mailer(__method__, comment) if default_mailer_active?
   end
 
   def validate_application(comment:, current_user:)
     deliver_event_webhook(__method__)
+    deliver_event_mailer(__method__, comment) if default_mailer_active?
 
     if enrollment.responsable_traitement.present?
       deliver_rgpd_email_for(:responsable_traitement)
@@ -48,5 +54,11 @@ class ApiEntrepriseNotifier < AbstractNotifier
     if enrollment.dpo.present?
       deliver_rgpd_email_for(:dpo)
     end
+  end
+
+  private
+
+  def default_mailer_active?
+    ENV["API_ENTREPRISE_MAILER_OFF"].nil?
   end
 end

--- a/app/notifiers/base_notifier.rb
+++ b/app/notifiers/base_notifier.rb
@@ -1,10 +1,4 @@
-class BaseNotifier
-  attr_reader :enrollment
-
-  def initialize(enrollment)
-    @enrollment = enrollment
-  end
-
+class BaseNotifier < AbstractNotifier
   def created
     EnrollmentMailer.with(
       to: enrollment.user.email,

--- a/app/notifiers/concerns/email_notifier_methods.rb
+++ b/app/notifiers/concerns/email_notifier_methods.rb
@@ -1,0 +1,55 @@
+module EmailNotifierMethods
+  protected
+
+  def deliver_created_mail_to_enrollment_creator
+    EnrollmentMailer.with(
+      to: enrollment.user.email,
+      target_api: enrollment.target_api,
+      enrollment_id: enrollment.id,
+      template: "create_application"
+    ).notification_email.deliver_later
+  end
+
+  def deliver_event_mailer(event, comment)
+    EnrollmentMailer.with(
+      to: enrollment.user.email,
+      target_api: enrollment.target_api,
+      enrollment_id: enrollment.id,
+      template: event.to_s,
+      message: comment
+    ).notification_email.deliver_later
+  end
+
+  def deliver_rgpd_email_for(entity)
+    RgpdMailer.with(
+      to: enrollment.public_send(entity).email,
+      target_api: enrollment.target_api,
+      enrollment_id: enrollment.id,
+      rgpd_role: Kernel.const_get("EnrollmentsController::#{entity.upcase}_LABEL"),
+      contact_label: enrollment.public_send("#{entity}_full_name"),
+      owner_email: enrollment.user.email,
+      nom_raison_sociale: enrollment.nom_raison_sociale,
+      intitule: enrollment.intitule
+    ).rgpd_contact_email.deliver_later
+  end
+
+  def notify_subscribers_by_email_for_sent_application(current_user: nil)
+    EnrollmentMailer.with(
+      to: enrollment.subscribers.map(&:email),
+      target_api: enrollment.target_api,
+      enrollment_id: enrollment.id,
+      template: "notify_application_sent",
+      applicant_email: current_user.email
+    ).notification_email.deliver_later
+  end
+
+  def notify_rgpd_contacts_by_email(responsable_traitement_email:, dpo_email:)
+    if responsable_traitement_email
+      deliver_rgpd_email_for(:responsable_traitement)
+    end
+
+    if dpo_email
+      deliver_rgpd_email_for(:dpo)
+    end
+  end
+end

--- a/app/notifiers/concerns/webhook_notifier_methods.rb
+++ b/app/notifiers/concerns/webhook_notifier_methods.rb
@@ -1,0 +1,20 @@
+module WebhookNotifierMethods
+  protected
+
+  def deliver_event_webhook(event)
+    DeliverEnrollmentWebhookWorker.perform_async(
+      @enrollment.target_api,
+      webhook_payload_for(event),
+      @enrollment.id
+    )
+  end
+
+  private
+
+  def webhook_payload_for(event)
+    WebhookSerializer.new(
+      @enrollment,
+      event.to_s
+    ).serializable_hash
+  end
+end

--- a/app/serializers/webhook_enrollment_owner_serializer.rb
+++ b/app/serializers/webhook_enrollment_owner_serializer.rb
@@ -1,0 +1,3 @@
+class WebhookEnrollmentOwnerSerializer < UserWithProfileSerializer
+  attributes :uid
+end

--- a/app/serializers/webhook_enrollment_serializer.rb
+++ b/app/serializers/webhook_enrollment_serializer.rb
@@ -1,0 +1,36 @@
+class WebhookEnrollmentSerializer < ActiveModel::Serializer
+  attributes :id,
+    :target_api,
+    :intitule,
+    :description,
+    :fondement_juridique_title,
+    :fondement_juridique_url,
+    :cgu_approved,
+    :additional_content,
+    :type_projet,
+    :data_recipients,
+    :data_retention_period,
+    :data_retention_comment,
+    :date_mise_en_production,
+    :status,
+    :data_retention_period,
+    :data_retention_comment,
+    :siret,
+    :nom_raison_sociale,
+    :organization_id,
+    :contacts,
+    :scopes,
+    :updated_at,
+    :created_at,
+    :previous_enrollment_id,
+    :copied_from_enrollment_id,
+    :linked_token_manager_id,
+    :volumetrie_approximative,
+    :dpo_is_informed
+
+  belongs_to :user, serializer: UserWithProfileSerializer
+  belongs_to :dpo, serializer: UserWithProfileSerializer
+  belongs_to :responsable_traitement, serializer: UserWithProfileSerializer
+
+  has_many :events, serializer: WebhookEventSerializer
+end

--- a/app/serializers/webhook_enrollment_serializer.rb
+++ b/app/serializers/webhook_enrollment_serializer.rb
@@ -33,4 +33,5 @@ class WebhookEnrollmentSerializer < ActiveModel::Serializer
   belongs_to :responsable_traitement, serializer: UserWithProfileSerializer
 
   has_many :events, serializer: WebhookEventSerializer
+  has_many :documents
 end

--- a/app/serializers/webhook_enrollment_serializer.rb
+++ b/app/serializers/webhook_enrollment_serializer.rb
@@ -28,7 +28,7 @@ class WebhookEnrollmentSerializer < ActiveModel::Serializer
     :volumetrie_approximative,
     :dpo_is_informed
 
-  belongs_to :user, serializer: UserWithProfileSerializer
+  belongs_to :user, serializer: WebhookEnrollmentOwnerSerializer
   belongs_to :dpo, serializer: UserWithProfileSerializer
   belongs_to :responsable_traitement, serializer: UserWithProfileSerializer
 

--- a/app/serializers/webhook_event_serializer.rb
+++ b/app/serializers/webhook_event_serializer.rb
@@ -1,0 +1,8 @@
+class WebhookEventSerializer < ActiveModel::Serializer
+  attributes :id,
+    :name,
+    :comment,
+    :created_at
+
+  has_one :user, serializer: UserWithProfileSerializer
+end

--- a/app/serializers/webhook_serializer.rb
+++ b/app/serializers/webhook_serializer.rb
@@ -1,0 +1,32 @@
+class WebhookSerializer
+  attr_reader :enrollment,
+    :event,
+    :extra_data
+
+  def initialize(enrollment, event, extra_data = {})
+    @enrollment = enrollment
+    @event = event
+    @extra_data = extra_data
+  end
+
+  def serializable_hash
+    {
+      event: event,
+      fired_at: now.to_i,
+      model_type: "Pass",
+      data: {
+        pass: enrollment_serialized
+      }.merge(extra_data)
+    }
+  end
+
+  private
+
+  def now
+    @now ||= Time.now
+  end
+
+  def enrollment_serialized
+    WebhookEnrollmentSerializer.new(enrollment).serializable_hash
+  end
+end

--- a/app/views/webhook_mailer/fail.text.erb
+++ b/app/views/webhook_mailer/fail.text.erb
@@ -1,0 +1,19 @@
+Votre endpoint <%= @webhook_url  %> n'accepte plus les appels de notre webhook depuis environ 10m.
+
+Les informations techniques sont les suivantes:
+
+**Payload**
+
+La payload envoyée:
+
+```
+<%= @payload %>
+```
+
+**Status**
+
+<%= @webhook_response_status %>
+
+**Body**
+
+<%= @webhook_response_body %>

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -1,0 +1,3 @@
+class ApplicationWorker
+  include Sidekiq::Worker
+end

--- a/app/workers/deliver_enrollment_webhook_worker.rb
+++ b/app/workers/deliver_enrollment_webhook_worker.rb
@@ -1,0 +1,114 @@
+require "http"
+require "digest"
+
+class DeliverEnrollmentWebhookWorker < ApplicationWorker
+  sidekiq_options queue: "webhooks"
+
+  def perform(target_api, payload, enrollment_id, tries_count = 0)
+    return if webhook_url(target_api).blank?
+    return if verify_token(target_api).blank?
+
+    response = request(target_api, payload)
+
+    if success_http_codes.include?(response.status)
+      handle_success(response.body, enrollment_id)
+    else
+      handle_error(response, target_api, payload, enrollment_id, tries_count)
+    end
+  end
+
+  private
+
+  def request(target_api, payload)
+    HTTP
+      .headers(
+        "Content-Type" => "application/json",
+        "X-Hub-Signature" => generate_hub_signature(target_api),
+        "X-Hub-Timestamp" => now.to_i
+      )
+      .post(
+        webhook_url(target_api),
+        json: payload
+      )
+  end
+
+  def handle_success(payload, enrollment_id)
+    json = JSON.parse(payload)
+
+    return unless json["token_id"].present?
+
+    Enrollment.find(enrollment_id).update(
+      linked_token_manager_id: json["token_id"]
+    )
+  rescue JSON::ParserError
+    nil
+  end
+
+  def handle_error(response, target_api, payload, enrollment_id, tries_count)
+    track_error(response, target_api, payload, tries_count)
+    notify_webhook_fail(target_api, payload, response) if tries_count == 4
+    reschedule_worker(target_api, payload, enrollment_id, tries_count)
+  end
+
+  def reschedule_worker(target_api, payload, enrollment_id, tries_count)
+    self.class.perform_in(
+      extract_waiting_time(tries_count),
+      target_api,
+      payload,
+      enrollment_id,
+      tries_count + 1
+    )
+  end
+
+  def track_error(response, target_api, payload, tries_count)
+    Sentry.set_extras(
+      {
+        target_api: target_api,
+        payload: payload,
+        tries_count: tries_count,
+        webhook_response_status: response.status,
+        webhook_response_body: response.body
+      }
+    )
+
+    Sentry.capture_message("Fail to call target's api webhook endpoint")
+  end
+
+  def notify_webhook_fail(target_api, payload, response)
+    WebhookMailer.with(
+      target_api: target_api,
+      payload: payload,
+      webhook_response_status: response.status.to_i,
+      webhook_response_body: response.body.to_s
+    ).fail.deliver_later
+  end
+
+  # https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry
+  def extract_waiting_time(tries_count)
+    (tries_count**4) + 15 + (rand(30) * (tries_count + 1))
+  end
+
+  def generate_hub_signature(target_api)
+    Digest::SHA256.base64digest("#{verify_token(target_api)}#{now.to_i}")
+  end
+
+  def webhook_url(target_api)
+    ENV["#{target_api.upcase}_WEBHOOK_URL"]
+  end
+
+  def verify_token(target_api)
+    ENV["#{target_api.upcase}_VERIFY_TOKEN"]
+  end
+
+  def success_http_codes
+    [
+      200,
+      201,
+      204
+    ]
+  end
+
+  def now
+    @now ||= Time.now
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,8 +36,7 @@ module DataPass
     config.public_file_server.enabled = false
 
     # Use a real queuing backend for Active Job (and separate queues per environment)
-    # config.active_job.queue_adapter     = :resque
-    # config.active_job.queue_name_prefix = "datapass_#{Rails.env}"
+    config.active_job.queue_adapter = :sidekiq
     config.action_mailer.perform_caching = false
 
     # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+Redis.exists_returns_integer = false

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,10 +1,8 @@
-if ENV["SENTRY_DSN"]
-  Sentry.init do |config|
-    config.dsn = ENV["SENTRY_DSN"]
+Sentry.init do |config|
+  config.dsn = ENV["SENTRY_DSN"]
 
-    config.breadcrumbs_logger = [:active_support_logger]
-    config.enabled_environments = %w[production]
+  config.breadcrumbs_logger = [:active_support_logger]
+  config.enabled_environments = %w[production]
 
-    config.traces_sample_rate = 1.0
-  end
+  config.traces_sample_rate = 1.0
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require "sidekiq/web"
+
 Rails.application.routes.draw do
   scope :api do
     resources :enrollments do
@@ -50,4 +52,12 @@ Rails.application.routes.draw do
   end
 
   get "/uploads/:model/:type/:mounted_as/:id/:filename", to: "documents#show", constraints: {filename: /[^\/]+/}
+
+  if Rails.env.development?
+    mount Sidekiq::Web => "/sidekiq"
+  else
+    authenticate :user, lambda { |u| u.is_administrator? } do
+      mount Sidekiq::Web => "/sidekiq"
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,11 +53,7 @@ Rails.application.routes.draw do
 
   get "/uploads/:model/:type/:mounted_as/:id/:filename", to: "documents#show", constraints: {filename: /[^\/]+/}
 
-  if Rails.env.development?
+  authenticate :user, lambda { |u| u.is_administrator? } do
     mount Sidekiq::Web => "/sidekiq"
-  else
-    authenticate :user, lambda { |u| u.is_administrator? } do
-      mount Sidekiq::Web => "/sidekiq"
-    end
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,8 @@
+:concurrency: 5
+:timeout: 25
+:queues:
+  - 'default'
+  - 'mailers'
+  - 'webhooks'
+:production:
+  :concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || 5 %>

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -115,7 +115,9 @@ Datapass et de votre système, il est impossible pour un attaquant de forger une
 requête et de taper sur votre système sans connaître la valeur du token de
 vérification.
 
-Il est **fortement recommandé** de vérifier la valeur `X-Hub-Signature-256`.
+⚠️ Il est **impératif de vérifier la valeur `X-Hub-Signature-256` dans votre système**, le cas contraire n'importe
+quel personne connaissant l'url de votre service pourra exploiter cette faille
+et donc générer des accès à vos données.
 
 Ci dessous un exemple (en ruby/rails) qui vérifie la valeur du `X-Hub-Signature-256`:
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,6 +1,6 @@
 ## Implémentation d'un wehbook
 
-Datapass possède un système de webhooks permettant de souscrire aux différents
+DataPass possède un système de webhooks permettant de souscrire aux différents
 changement d'état d'une demande. Par défaut ce système est désactivé (en faveur
 d'emails de notifications et d'un appel via un bridge (code spécifique au
 fournisseur de service) lors d'une validation d'une demande).
@@ -12,18 +12,18 @@ statistiques..).
 Le système de webhooks utilise l'approche du token de vérification et du header
 `X-Hub-Signature-256` permettant d'authentifier les appels depuis le endpoint cible.
 
-L'implémentation des webhooks s'effectue en 2 étapes: une partie sur Datapass et
+L'implémentation des webhooks s'effectue en 2 étapes: une partie sur DataPass et
 une partie sur votre système.
 
-### Partie 1: Datapass
+### Partie 1: DataPass
 
-Afin de pouvoir activer les webhooks sur Datapass, il faut définir 2 variables
+Afin de pouvoir activer les webhooks sur DataPass, il faut définir 2 variables
 d'environnement:
 
 1. Une jeton de vérification qui permettra de signer les appels ;
 2. L'URL du endpoint qui acceptera les appels webhooks.
 
-Avec le service identifié dans Datapass comme `super_service`, les variables
+Avec le service identifié dans DataPass comme `super_service`, les variables
 seront:
 
 1. `SUPER_SERVICE_VERIFY_TOKEN`
@@ -103,7 +103,7 @@ Votre serveur doit obligatoirement répondre avec un status de succès. Les code
 HTTP considérés comme étant un succès sont `200`, `201` et `204`.
 
 Niveau sécurité, afin de garantir que la payload envoyée est bien émise par
-Datapass, 2 headers sont ajoutés à la requête :
+DataPass, 2 headers sont ajoutés à la requête :
 
 - `X-Hub-Signature-256`, `string` : [HMAC en SHA256 ( Hash-based Message Authentication Code
   )](https://fr.wikipedia.org/wiki/HMAC) ayant pour clé la valeur de jeton de
@@ -111,7 +111,7 @@ Datapass, 2 headers sont ajoutés à la requête :
 
 Ce header permet d'authentifier chaque payload reçu par votre
 système : en effet, vu que le token de vérification est seulement connu de
-Datapass et de votre système, il est impossible pour un attaquant de forger une
+DataPass et de votre système, il est impossible pour un attaquant de forger une
 requête et de taper sur votre système sans connaître la valeur du token de
 vérification.
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,148 @@
+## Implémentation d'un wehbook
+
+Datapass possède un système de webhooks permettant de souscrire aux différents
+changement d'état d'une demande. Par défaut ce système est désactivé (en faveur
+d'emails de notifications et d'un appel via un bridge (code spécifique au
+fournisseur de service) lors d'une validation d'une demande).
+
+Si vous voulez avoir un contrôle plus fin du cycle de vie des demandes, vous
+pouvez utiliser ce système (par exemple pour gérer un CRM, mettre en place des
+statistiques..).
+
+Le système de webhooks utilise l'approche du token de vérification et du header
+`X-Hub-Signature` permettant d'authentifier les appels depuis le endpoint cible.
+
+L'implémentation des webhooks s'effectue en 2 étapes: une partie sur Datapass et
+une partie sur votre système.
+
+### Partie 1: Datapass
+
+Afin de pouvoir activer les webhooks sur Datapass, il faut définir 2 variables
+d'environnement:
+
+1. Une jeton de vérification qui permettra de signer les appels ;
+2. L'URL du endpoint qui acceptera les appels webhooks.
+
+Avec le service identifié dans Datapass comme `super_service`, les variables
+seront:
+
+1. `SUPER_SERVICE_VERIFY_TOKEN`
+1. `SUPER_SERVICE_WEBHOOK_URL`
+
+Par exemple pour API Entreprise, identifié comme `api_entreprise`, les variables
+sont:
+
+1. `API_ENTREPRISE_VERIFY_TOKEN`
+1. `API_ENTREPRISE_WEBHOOK_URL`
+
+Dès que ces 2 variables sont définies, l'activation du système de webhook
+s'effectue en créant un notifier spécifique au système portant le nom de
+`SuperServiceNotifier`, qui hérite de
+[`AbstractNotifier`](./app/notifiers/abstract_notifier.rb).
+
+Chacune des méthodes correspond à un événement asssocié à la demande datapass,
+défini dans le modèle `Enrollment` (la description de chacun de ces événements
+se trouve plus bas dans ce document)
+
+Le comportement par défaut est défini dans
+[`BaseNotifier`](./app/notifiers/base_notifier.rb)
+
+Il est possible de mixer, en fonction de l'événement, l'envoi d'email ou de
+webhooks. Un exemple d'implémentation qui utilise des webhooks et des emails
+est disponible ici:
+[`ApiEntrepriseNotifier`](./app/notifiers/api_entreprise_notifier.rb)
+
+### Partie 2: Système recevant les webhooks
+
+Le système de webhook effectue des requêtes HTTP de type POST, avec comme `body`
+un json qui est sous le format ci-dessous :
+
+```json
+{
+  "event": "refused",
+  "fired_at": 1628253953,
+  "model_type": "Pass",
+  "data": {
+    "pass": pass_data
+  }
+}
+```
+
+Avec:
+
+- `event`, `string`: l'événement associé au changement d'état de la demande.
+  Les valeurs possibles sont:
+  - `created`: la demande datapass vient d'être créée ;
+  - `updated`: la demande datapass a été mise à jour par le demandeur ;
+  - `send_application`: la demande datapass a été envoyée par le demandeur ;
+  - `refuse_application`: la demande datapass a été refusée par un instructeur ;
+  - `review_application`: la demande datapass a été instruite par un instructeur et
+    demande des modifications de la part du demandeur ;
+  - `validate_application`: la demande datapass a été validée par un instructeur ;
+  - `notify`: un instructeur a relancé la demande en cours d'édition par le
+    demandeur ;
+  - `owner_updated`: le demandeur de la demande datapass a été mise à jour
+    par le demandeur ou un instructeur ;
+  - `rgpd_contact_updated`: le DPO ou le responsable de traitement a été mis à
+    jour par le demandeur ou un instructeur ;
+- `fired_at`, `timestamp`: timestamp correspondant au moment où le webhook a été
+  déclenché ;
+- `model_type`, `string`: correspond au modèle de donnée. Pour le moment il n'y
+  a que `Pass` comme valeur
+- `data`, `json`: données ayant à minima les informations de la demande dans la
+  clé `pass`, d'autres clés peuvent être présentes.
+  `pass_data` utilise le serializer `WebhookEnrollmentSerializer`, et embarque
+  l'ensemble des événements associé à la demande, ce qui permet de retrouver
+  l'initiateur de l'événement (théoriquement il s'agit de la première entrée
+  `events`) ;
+
+La requête HTTP possède comme `Application-Type` la valeur
+`application/json`
+
+Votre serveur doit obligatoirement répondre avec un status de succès. Les codes
+HTTP considérés comme étant un succès sont `200`, `201` et `204`.
+
+Niveau sécurité, afin de garantir que la payload envoyée est bien émise par
+Datapass, 2 headers sont ajoutés à la requête :
+
+- `X-Hub-Timestamp`, `timestamp` : correspond au timestamp d'envoi effective du webhook ;
+- `X-Hub-Signature`, `string` : sha256 en base64 de la concatenation
+  du token de vérification et du `X-Hub-Timestamp` ;
+
+Ces deux headers permettent d'authentifier chaque payload reçu par votre
+système : en effet, vu que le token de vérification est seulement connu de
+Datapass et de votre système, il est impossible pour un attaquant de forger une
+requête et de taper sur votre système sans connaître la valeur du token de
+vérification.
+
+La présence du timestamp permet aussi à votre système d'exclure des potentiels
+appels ayant un timestamp dans le passé, dans le cas où un attaquant intercepte
+une des payloads et tente d'utiliser les 2 headers d'un appel passé.
+
+Il est **fortement recommandé** de vérifier la valeur `X-Hub-Signature` et d'exclure
+les appels ayant un `X-Hub-Timestamp` inférieur au dernier timestamp reçu par
+votre système.
+
+Ci dessous un exemple (en ruby/rails) qui vérifie la valeur du `X-Hub-Signature:`
+
+```ruby
+hub_signature = request.headers['X-Hub-Signature']
+hub_timestamp = request.headers['X-Hub-Timestamp']
+verify_token = ENV['DATAPASS_WEBHOOK_VERIFY_TOKEN']
+
+compute_hub_signature = Digest::SHA256.base64digest("#{verify_token}#{hub_timestamp}")
+
+# La valeur ci-dessous est true si la signature est valide
+hub_signature == compute_hub_signature
+```
+
+Lors de l'événement `validated`, si votre système répond avec un ID de jeton
+celui-ci sera affecté à la demande.
+
+Le format attendu est au format json:
+
+```json
+{
+  "token_id": "1234567890asdfghjkl"
+}
+```

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -132,7 +132,7 @@ compute_hub_signature = 'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new(
 Rack::Utils.secure_compare(hub_signature, compute_hub_signature)
 ```
 
-Lors de l'événement `validated`, si votre système répond avec un ID de jeton
+Lors de l'événement `validate_application`, si votre système répond avec un ID de jeton
 celui-ci sera affecté à la demande.
 
 Le format attendu est au format json:

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -40,7 +40,7 @@ s'effectue en créant un notifier spécifique au système portant le nom de
 `SuperServiceNotifier`, qui hérite de
 [`AbstractNotifier`](./app/notifiers/abstract_notifier.rb).
 
-Chacune des méthodes correspond à un événement asssocié à la demande datapass,
+Chacune des méthodes correspond à un événement associé à la demande datapass,
 défini dans le modèle `Enrollment` (la description de chacun de ces événements
 se trouve plus bas dans ce document)
 

--- a/spec/bridges/abstract_webhook_bridge_spec.rb
+++ b/spec/bridges/abstract_webhook_bridge_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe AbstractWebhookBridge, type: :bridge do
+  let(:dummy_webhook_bridge) do
+    Class.new(AbstractWebhookBridge)
+  end
+
+  subject { dummy_webhook_bridge.call(enrollment) }
+
+  let(:enrollment) { create(:enrollment, :franceconnect, :validated) }
+  let(:webhook_payload) { WebhookSerializer.new(enrollment, "validated").serializable_hash }
+
+  it "calls DeliverEnrollmentWebhookWorker with enrollment's target api and valid payload" do
+    expect(DeliverEnrollmentWebhookWorker).to receive(:perform_async).with(
+      enrollment.target_api,
+      webhook_payload,
+      enrollment.id
+    )
+
+    subject
+  end
+end

--- a/spec/mailers/webhook_mailer_spec.rb
+++ b/spec/mailers/webhook_mailer_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe WebhookMailer, type: :mailer do
+  describe ".fail" do
+    subject(:mail) do
+      described_class.with(
+        target_api: target_api,
+        payload: payload,
+        webhook_response_status: webhook_response_status,
+        webhook_response_body: webhook_response_body
+      ).fail
+    end
+
+    let(:target_api) { "franceconnect" }
+    let(:payload) { {lol: "oki"} }
+    let(:webhook_response_body) { "PANIK" }
+    let(:webhook_response_status) { 500 }
+
+    let(:webhook_url) { "https://service.api.gouv.fr/webhook" }
+
+    before do
+      ENV["#{target_api.upcase}_WEBHOOK_URL"] = webhook_url
+    end
+
+    after do
+      ENV["#{target_api.upcase}_WEBHOOK_URL"] = nil
+    end
+
+    let!(:franceconnect_instructors) { create_list(:user, 2, roles: ["franceconnect:instructor"]) }
+    let!(:foreign_instructor) { create(:user, roles: ["api_entreprise:instructor"]) }
+
+    it "sends email to target api instructors, with datapass@api.gouv.fr in cc and from" do
+      expect(mail.to).to eq(franceconnect_instructors.pluck(:email))
+
+      expect(mail.from).to eq(["datapass@api.gouv.fr"])
+      expect(mail.cc).to eq(["datapass@api.gouv.fr"])
+    end
+
+    it "renders relevant information in body" do
+      expect(mail.body.encoded).to include(webhook_url)
+      expect(mail.body.encoded).to include("\"lol\": \"oki\"")
+      expect(mail.body.encoded).to include(webhook_response_status.to_s)
+      expect(mail.body.encoded).to include(webhook_response_body)
+    end
+  end
+end

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -23,10 +23,11 @@ RSpec.describe Enrollment, type: :model do
   end
 
   describe "validate_application transition" do
-    subject { enrollment.validate_application(user_id: user.id, comment: "whatever") }
+    subject { enrollment.validate_application(params) }
 
     let(:user) { create(:user) }
     let(:enrollment) { create(:enrollment, target_api, :sent) }
+    let(:params) { {user_id: user.id, comment: "whatever"} }
 
     context "with api_particulier as target api" do
       let(:target_api) { :api_particulier }
@@ -91,8 +92,8 @@ RSpec.describe Enrollment, type: :model do
     context "with francerelance_fc as target api" do
       let(:target_api) { :francerelance_fc }
 
-      it "runs FranceconnectBridge" do
-        expect(FranceconnectBridge).to receive(:call).with(enrollment)
+      it "runs FrancerelanceFcBridge" do
+        expect(FrancerelanceFcBridge).to receive(:call).with(enrollment)
 
         subject
       end

--- a/spec/notifiers/api_entreprise_notifier_spec.rb
+++ b/spec/notifiers/api_entreprise_notifier_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe ApiEntrepriseNotifier, type: :notifier do
+  let(:instance) { described_class.new(enrollment) }
+
+  let(:enrollment) { create(:enrollment, :api_entreprise) }
+  let(:user) { create(:user) }
+
+  describe "webhook events" do
+    shared_examples "notifier webhook delivery" do
+      it "calls webhook" do
+        expect(DeliverEnrollmentWebhookWorker).to receive(:perform_async).with(
+          enrollment.target_api,
+          WebhookSerializer.new(
+            enrollment,
+            event
+          ).serializable_hash,
+          enrollment.id
+        )
+
+        subject
+      end
+    end
+
+    describe "#created" do
+      subject { instance.created }
+
+      include_examples "notifier webhook delivery" do
+        let(:event) { "created" }
+      end
+    end
+
+    describe "#updated" do
+      subject { instance.updated(diff: "diff", user_id: user.id) }
+
+      include_examples "notifier webhook delivery" do
+        let(:event) { "updated" }
+      end
+    end
+
+    describe "#notify" do
+      subject { instance.notify(comment: "comment", current_user: user) }
+
+      include_examples "notifier webhook delivery" do
+        let(:event) { "notify" }
+      end
+    end
+
+    describe "#review_application" do
+      subject { instance.review_application(comment: "comment", current_user: user) }
+
+      include_examples "notifier webhook delivery" do
+        let(:event) { "review_application" }
+      end
+    end
+
+    describe "#refuse_application" do
+      subject { instance.refuse_application(comment: "comment", current_user: user) }
+
+      include_examples "notifier webhook delivery" do
+        let(:event) { "refuse_application" }
+      end
+    end
+
+    describe "#validate_application" do
+      subject { instance.validate_application(comment: "comment", current_user: user) }
+
+      include_examples "notifier webhook delivery" do
+        let(:event) { "validate_application" }
+      end
+    end
+  end
+
+  describe "emails events" do
+    describe "#rgpd_contact_updated" do
+      let(:enrollment) { create(:enrollment, :api_entreprise, :with_dpo) }
+
+      subject { instance.rgpd_contact_updated(diff: "diff", user_id: user.id, dpo_email: user.email, responsable_traitement_email: nil) }
+
+      it "delivers an email" do
+        expect {
+          subject
+        }.to have_enqueued_job.on_queue("mailers")
+      end
+    end
+  end
+
+  describe "#owner_updated" do
+    subject { instance.owner_updated(diff: "diff", user_id: user.id) }
+
+    it "does nothing" do
+      expect(DeliverEnrollmentWebhookWorker).not_to receive(:perform_async)
+
+      expect {
+        subject
+      }.not_to have_enqueued_job.on_queue("mailers")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
 require "rspec/rails"
+require "sidekiq/testing"
 require "spec_helper"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
@@ -51,6 +52,18 @@ RSpec.configure do |config|
     FileUtils.rm_rf(
       Rails.root.join("tmp/uploads")
     )
+  end
+
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
+
+  config.before(:each, type: :worker) do
+    Sidekiq::Testing.inline!
+  end
+
+  config.after(:each, type: :worker) do
+    Sidekiq::Testing.fake!
   end
 
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/serializers/webhook_enrollment_serializer_spec.rb
+++ b/spec/serializers/webhook_enrollment_serializer_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe WebhookEnrollmentSerializer, type: :serializer do
+  subject(:payload) { described_class.new(enrollment).serializable_hash }
+
+  let(:enrollment) { create(:enrollment, :franceconnect, :complete) }
+
+  let!(:created_event) { create(:event, :created, enrollment: enrollment, created_at: 3.hours.ago) }
+  let!(:refused_event) { create(:event, :refused, enrollment: enrollment, created_at: 2.hours.ago) }
+  let!(:validated_event) { create(:event, :validated, enrollment: enrollment, created_at: 1.hours.ago) }
+
+  it "renders valid data" do
+    expect(payload).to have_key(:id)
+
+    %i[
+      dpo
+      responsable_traitement
+      user
+    ].each do |user_kind|
+      expect(payload).to have_key(user_kind)
+
+      expect(payload[user_kind]).to have_key(:family_name)
+      expect(payload[user_kind]).to have_key(:email)
+    end
+
+    expect(payload).to have_key(:events)
+
+    expect(payload[:events][0]).to be_present
+    expect(payload[:events][0]).not_to have_key(:diff)
+    expect(payload[:events][0][:name]).to eq("created")
+
+    expect(payload[:events][0][:user]).to have_key(:email)
+    expect(payload[:events][0][:user]).to have_key(:family_name)
+
+    expect(payload[:events][-1][:name]).to eq("validated")
+  end
+end

--- a/spec/serializers/webhook_enrollment_serializer_spec.rb
+++ b/spec/serializers/webhook_enrollment_serializer_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe WebhookEnrollmentSerializer, type: :serializer do
       expect(payload[user_kind]).to have_key(:email)
     end
 
+    expect(payload[:user]).to have_key(:uid)
+
     expect(payload).to have_key(:events)
 
     expect(payload[:events][0]).to be_present

--- a/spec/serializers/webhook_serializer_spec.rb
+++ b/spec/serializers/webhook_serializer_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe WebhookSerializer, type: :serializer do
+  describe "#serializable_hash" do
+    subject { described_class.new(enrollment, event, extra_data) }
+
+    let(:enrollment) { create(:enrollment, :franceconnect, :complete) }
+    let(:enrollment_serialized) { WebhookEnrollmentSerializer.new(enrollment).serializable_hash }
+    let(:event) { "validated" }
+    let(:extra_data) { {comment: "its ok!"} }
+
+    before do
+      Timecop.freeze
+    end
+
+    after do
+      Timecop.freeze
+    end
+
+    it do
+      expect(subject.serializable_hash).to eq(
+        {
+          event: event,
+          fired_at: Time.now.to_i,
+          model_type: "Pass",
+          data: {
+            pass: enrollment_serialized
+          }.merge(extra_data)
+        }
+      )
+    end
+  end
+end

--- a/spec/workers/deliver_enrollment_webhook_worker_spec.rb
+++ b/spec/workers/deliver_enrollment_webhook_worker_spec.rb
@@ -1,0 +1,184 @@
+require "rails_helper"
+
+RSpec.describe DeliverEnrollmentWebhookWorker, type: :worker do
+  subject { described_class.perform_async(target_api, payload, enrollment.id) }
+
+  let(:target_api) { "api_entreprise" }
+  let(:payload) do
+    {
+      "lol" => "oki"
+    }
+  end
+  let(:enrollment) { create(:enrollment, :franceconnect) }
+
+  let(:webhook_post_request) do
+    stub_request(:post, webhook_url).with(
+      body: payload.to_json,
+      headers: {
+        "Content-Type" => "application/json",
+        "X-Hub-Signature" => hub_signature,
+        "X-Hub-Timestamp" => Time.now.to_i
+      }
+    ).to_return(status: status, body: body)
+  end
+  let(:status) { [200, 201, 204].sample }
+  let(:body) { "whatever" }
+
+  let(:webhook_url) { "https://service.gouv.fr/webhook" }
+  let(:verify_token) { "verify_token" }
+  let(:hub_signature) { Digest::SHA256.base64digest("#{verify_token}#{Time.now.to_i}") }
+
+  before do
+    Timecop.freeze
+
+    webhook_post_request
+  end
+
+  after do
+    Timecop.return
+
+    ENV["API_ENTREPRISE_WEBHOOK_URL"] = nil
+    ENV["API_ENTREPRISE_VERIFY_TOKEN"] = nil
+  end
+
+  context "when target api's webhook url is not defined" do
+    before do
+      ENV["API_ENTREPRISE_VERIFY_TOKEN"] = verify_token
+    end
+
+    it "does nothing" do
+      subject
+
+      expect(webhook_post_request).not_to have_been_requested
+    end
+  end
+
+  context "when target api's verify token is not defined" do
+    before do
+      ENV["API_ENTREPRISE_WEBHOOK_URL"] = webhook_url
+    end
+
+    it "does nothing" do
+      subject
+
+      expect(webhook_post_request).not_to have_been_requested
+    end
+  end
+
+  context "when all target api webhook env vars are defined" do
+    before do
+      ENV["API_ENTREPRISE_WEBHOOK_URL"] = webhook_url
+      ENV["API_ENTREPRISE_VERIFY_TOKEN"] = verify_token
+    end
+
+    it "performs a post request on target api's webhook url with payload and headers" do
+      subject
+
+      expect(webhook_post_request).to have_been_requested
+    end
+
+    describe "target's api webhook url status" do
+      subject { described_class.perform_async(target_api, payload, enrollment.id, tries_count) }
+
+      before do
+        allow(described_class).to receive(:perform_in)
+      end
+
+      let(:tries_count) { 0 }
+
+      context "when endpoint respond with a success" do
+        it "does not reschedule worker" do
+          expect(described_class).not_to receive(:perform_in)
+
+          subject
+        end
+
+        it "does not track on sentry" do
+          expect(Sentry).not_to receive(:capture_message)
+
+          subject
+        end
+
+        context "when body is a json with a token_id key" do
+          let(:token_id) { "token_id" }
+
+          let(:body) do
+            {
+              token_id: token_id
+            }.to_json
+          end
+
+          it "stores this token id in enrollment" do
+            expect {
+              subject
+            }.to change { enrollment.reload.linked_token_manager_id }.to(token_id)
+          end
+        end
+      end
+
+      context "when endpoint respond with an error (400 to 599 status)" do
+        let(:status) { rand(400..599) }
+
+        it "reschedules worker with incremented tries count" do
+          expect(described_class).to receive(:perform_in).with(
+            instance_of(Integer),
+            target_api,
+            payload,
+            enrollment.id,
+            tries_count + 1
+          )
+
+          subject
+        end
+
+        it "tracks on sentry" do
+          expect(Sentry).to receive(:capture_message)
+
+          subject
+        end
+
+        context "when tries count is not 4" do
+          let(:tries_count) { ([*1..100] - [4]).sample }
+
+          it "does not send an email through WebhookMailer" do
+            expect(ActionMailer::Parameterized::DeliveryJob).not_to(
+              have_been_enqueued.with(
+                "WebhookMailer",
+                "fail",
+                anything,
+                {
+                  target_api: target_api,
+                  payload: payload,
+                  webhook_response_status: status,
+                  webhook_response_body: body
+                }
+              )
+            )
+          end
+        end
+
+        context "when tries count is 4 (5th attempt, ~10m)" do
+          let(:tries_count) { 4 }
+
+          it "sends an email through WebhookMailer" do
+            subject
+
+            expect(ActionMailer::Parameterized::DeliveryJob).to(
+              have_been_enqueued.with(
+                "WebhookMailer",
+                "fail",
+                anything,
+                {
+                  target_api: target_api,
+                  payload: payload,
+                  webhook_response_status: status,
+                  webhook_response_body: body
+                }
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
TODO

* [x] Introduce serializer for webhooks
* [x] Refactor bridges
* [x] Configurer activejob pour utiliser sidekiq
* [x] Configurer sidekiq avec un fichier yaml
* [x] Se mettre d'accord sur la payload finale de l'enrollment ( cf `app/serializers/webhook_enrollment_serializer.rb` )
* [x] model_type, changer Enrollment en Pass
* [x] Si l'url d'un webhook est en défaut après 5 tentatives (~10m), on envoi un email à aux subscribers + datapass@api.gouv.fr (à vérifier) en cc:
* [x] Monter un SidekiqUI pour les administrators
* Non, tout dans le serializer de l'enrollment ~~Quid du `user_id` qu'on ajoute dans les data ? Est-ce que l'on crée une clé `initiator` où on met la payload du user ? imo oui~~
* [x] data -> enrollment avec events, comment et instructor (not sure pour les 2 derniers)
* [x] Notifier -> introduction d'un `AbstractWebhookNotifier` qui implémente ce qu'il faut
* [x] Héritage de `AbstractWebhookNotifier` pour API Entreprise
* [x] Bridge ApiEntreprise
* ML Transformer les bridges en jobs + tracking des erreurs sur Sentry (simili webhook)
* [x] Si un `token_id` est présent le stocker sur la demande
* [x] Gérer tous les 2xx pour le worker (201 et 204 sont valides en vrai).
* [x] Documentation