### PR TITLE
fix: TypeError on notify event for enrollments

### DIFF
--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -118,7 +118,7 @@ class EnrollmentsController < ApplicationController
 
     if @enrollment.save
       @enrollment.events.create(name: "created", user_id: current_user.id)
-      @enrollment.notify("created")
+      @enrollment.notify_event("created")
 
       render json: @enrollment
     else
@@ -132,7 +132,7 @@ class EnrollmentsController < ApplicationController
 
     if @enrollment.update(permitted_attributes(@enrollment))
       @enrollment.events.create(name: "updated", user_id: current_user.id, diff: @enrollment.previous_changes)
-      @enrollment.notify("updated", user_id: current_user.id, diff: @enrollment.previous_changes)
+      @enrollment.notify_event("updated", user_id: current_user.id, diff: @enrollment.previous_changes)
 
       render json: @enrollment
     else
@@ -189,7 +189,7 @@ class EnrollmentsController < ApplicationController
       user_id: current_user.id,
       comment: params[:comment]
     )
-      @enrollment.notify(
+      @enrollment.notify_event(
         event,
         comment: params[:comment],
         current_user: current_user
@@ -207,7 +207,7 @@ class EnrollmentsController < ApplicationController
 
     if @enrollment.update(permitted_attributes(@enrollment))
       @enrollment.events.create(name: "updated", user_id: current_user.id, diff: @enrollment.previous_changes)
-      @enrollment.notify("owner_updated", user_id: current_user.id, diff: @enrollment.previous_changes)
+      @enrollment.notify_event("owner_updated", user_id: current_user.id, diff: @enrollment.previous_changes)
 
       render json: @enrollment
     else
@@ -221,7 +221,7 @@ class EnrollmentsController < ApplicationController
 
     if @enrollment.update(permitted_attributes(@enrollment))
       @enrollment.events.create(name: "updated", user_id: current_user.id, diff: @enrollment.previous_changes)
-      @enrollment.notify(
+      @enrollment.notify_event(
         "rgpd_contact_updated",
         user_id: current_user.id,
         diff: @enrollment.previous_changes,

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -113,7 +113,7 @@ class Enrollment < ActiveRecord::Base
     end
   end
 
-  def notify(event, *args)
+  def notify_event(event, *args)
     notifier_class.new(self).public_send(event, *args)
   end
 

--- a/app/notifiers/base_notifier.rb
+++ b/app/notifiers/base_notifier.rb
@@ -42,6 +42,10 @@ class BaseNotifier
     ).notification_email.deliver_later
   end
 
+  def notify(comment:, current_user:)
+    deliver_event_mailer(__method__, comment)
+  end
+
   def review_application(comment:, current_user:)
     deliver_event_mailer(__method__, comment)
   end


### PR DESCRIPTION
The method `Enrollment#notify` overrided the state method of the same
name which causes a 500 error on this specific event.

The `notify` method to calls notifiers has been renamed to
`notify_event`.

Closes https://sentry.data.gouv.fr/organizations/sentry/issues/12787/