### PR TITLE
feat: add 'demarche' field to enrollment's payload in webhook

### DIFF
--- a/app/serializers/webhook_enrollment_serializer.rb
+++ b/app/serializers/webhook_enrollment_serializer.rb
@@ -2,6 +2,7 @@ class WebhookEnrollmentSerializer < ActiveModel::Serializer
   attributes :id,
     :intitule,
     :description,
+    :demarche,
     :status,
     :siret,
     :scopes,

--- a/spec/serializers/webhook_enrollment_serializer_spec.rb
+++ b/spec/serializers/webhook_enrollment_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe WebhookEnrollmentSerializer, type: :serializer do
 
   it "renders valid data" do
     expect(payload).to have_key(:id)
+    expect(payload).to have_key(:demarche)
 
     expect(payload).to have_key(:team_members)
 


### PR DESCRIPTION
This field allows data providers to get distinction between enrollments.

For API Entreprise it will enables us to distinct users with a progiciel, and which one.